### PR TITLE
Make maven plugin and binary versions configurable

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.5
+sbt.version = 0.13.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,6 +2,6 @@ logLevel := Level.Warn
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.2.1")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
+//addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
 
 libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value

--- a/src/main/resources/jp/leafytree/sbt/pom.xml
+++ b/src/main/resources/jp/leafytree/sbt/pom.xml
@@ -12,7 +12,7 @@
             <plugin>
                 <groupId>com.github.klieber</groupId>
                 <artifactId>phantomjs-maven-plugin</artifactId>
-                <version>0.4</version>
+                <version>${sbtphantomjs.mavenPluginVersion}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -21,7 +21,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <version>1.9.8</version>
+                    <version>${sbtphantomjs.phantomJsVersion}</version>
                     <outputDirectory>${sbtphantomjs.outputDir}/phantomjs</outputDirectory>
                 </configuration>
             </plugin>

--- a/src/sbt-test/install/old/build.sbt
+++ b/src/sbt-test/install/old/build.sbt
@@ -2,4 +2,4 @@ val old = (project in file(".")).enablePlugins(SbtPhantomJs)
 
 (run in Compile) <<= (run in Compile) dependsOn (installPhantomJs)
 
-libraryDependencies += ("com.github.detro.ghostdriver" % "phantomjsdriver" % "1.1.0")
+libraryDependencies += "com.codeborne" % "phantomjsdriver" % "1.2.1"

--- a/src/sbt-test/install/simple/build.sbt
+++ b/src/sbt-test/install/simple/build.sbt
@@ -2,4 +2,4 @@ val simple = (project in file(".")).enablePlugins(PhantomJs)
 
 (run in Compile) <<= (run in Compile) dependsOn (installPhantomJs)
 
-libraryDependencies += ("com.github.detro.ghostdriver" % "phantomjsdriver" % "1.1.0")
+libraryDependencies += "com.codeborne" % "phantomjsdriver" % "1.2.1"

--- a/src/sbt-test/setup/scalatest/build.sbt
+++ b/src/sbt-test/setup/scalatest/build.sbt
@@ -2,7 +2,7 @@ val scalatest = (project in file(".")).enablePlugins(PhantomJs)
 
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "2.2.1" % "test",
-  "com.github.detro.ghostdriver" % "phantomjsdriver" % "1.1.0"
+  "com.codeborne" % "phantomjsdriver" % "1.2.1"
 )
 
 javaOptions in Test ++= PhantomJs.setup(baseDirectory.value)

--- a/src/sbt-test/setup/simple/build.sbt
+++ b/src/sbt-test/setup/simple/build.sbt
@@ -1,5 +1,5 @@
 val simple = (project in file(".")).enablePlugins(PhantomJs)
 
-libraryDependencies += ("com.github.detro.ghostdriver" % "phantomjsdriver" % "1.1.0")
+libraryDependencies += "com.codeborne" % "phantomjsdriver" % "1.2.1"
 
 javaOptions ++= PhantomJs.setup(baseDirectory.value)

--- a/src/sbt-test/setup/specs2/build.sbt
+++ b/src/sbt-test/setup/specs2/build.sbt
@@ -2,7 +2,7 @@ val specs2 = (project in file(".")).enablePlugins(PhantomJs)
 
 libraryDependencies ++= Seq(
   "org.specs2" %% "specs2-core" % "2.4.15" % "test",
-  "com.github.detro.ghostdriver" % "phantomjsdriver" % "1.1.0"
+  "com.codeborne" % "phantomjsdriver" % "1.2.1"
 )
 
 javaOptions in Test ++= PhantomJs.setup(baseDirectory.value)


### PR DESCRIPTION
This PR upgrades to PhantomJS 2.0.0 by default, and also to the latest phantomjs-maven-plugn (v 0.7). It also makes those versions configurable via SBT.
